### PR TITLE
common 모둘 사용 시 빌드 안되는 문제 수정

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -3,7 +3,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 val jar: Jar by tasks
 val bootJar: BootJar by tasks
 
-jar.enabled = false
+jar.enabled = true
 bootJar.enabled = false
 
 plugins {}


### PR DESCRIPTION
commone 빌드 설정 jar.enabled을 true로 변경하여 해결