### PR TITLE
Summoner가 User 객체 대신 userId를 가지도록 변경

### DIFF
--- a/common/src/main/kotlin/dev/yangsijun/gol/common/entity/league/League.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/entity/league/League.kt
@@ -11,7 +11,7 @@ import org.springframework.data.mongodb.core.index.CompoundIndex
 import org.springframework.data.mongodb.core.mapping.Document
 
 @Document
-@CompoundIndex(name = "cmp-idx-by_id", def = "{'summoners.summoner.user.id': 1, 'summoners.id': 1, 'createdDate': -1}", unique = true)
+@CompoundIndex(name = "cmp-idx-by_id", def = "{'summoners.summoner.userId': 1, 'summoners.id': 1, 'createdDate': -1}", unique = true)
 @CompoundIndex(name = "cmp-idx-by_data", def = "{'createdDate': -1}", unique = true)
 class League(
     @Id var id: ObjectId? = null,

--- a/common/src/main/kotlin/dev/yangsijun/gol/common/entity/match/Match.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/entity/match/Match.kt
@@ -8,7 +8,7 @@ import org.springframework.data.mongodb.core.index.CompoundIndex
 import org.springframework.data.mongodb.core.mapping.Document
 
 @Document
-@CompoundIndex(name = "cmp-idx-by_id", def = "{'summoners.summoner.user.id': 1, 'summoners.id': 1, 'createdDate': -1}", unique = true)
+@CompoundIndex(name = "cmp-idx-by_id", def = "{'summoners.summoner.userId': 1, 'summoners.id': 1, 'createdDate': -1}", unique = true)
 @CompoundIndex(name = "cmp-idx-by_data", def = "{'createdDate': -1}", unique = true)
 @CompoundIndex(name = "cmp-idx-by_match", def = "{'data.metadata.matchId': -1}", unique = true)
 class Match(

--- a/common/src/main/kotlin/dev/yangsijun/gol/common/entity/ranking/Ranking.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/entity/ranking/Ranking.kt
@@ -9,7 +9,7 @@ import org.springframework.data.mongodb.core.index.CompoundIndex
 import org.springframework.data.mongodb.core.mapping.Document
 
 @Document
-@CompoundIndex(name = "cmp-idx-by_id", def = "{'summoners.summoner.user.id': 1, 'summoners.id': 1, 'createdDate': -1}", unique = true)
+@CompoundIndex(name = "cmp-idx-by_id", def = "{'summoners.summoner.userId': 1, 'summoners.id': 1, 'createdDate': -1}", unique = true)
 @CompoundIndex(name = "cmp-idx-by_data", def = "{'createdDate': -1}", unique = true)
 class Ranking(
     @Id var id: ObjectId? = null,

--- a/common/src/main/kotlin/dev/yangsijun/gol/common/entity/statistics/Statistics.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/entity/statistics/Statistics.kt
@@ -8,7 +8,7 @@ import org.springframework.data.mongodb.core.index.CompoundIndex
 import org.springframework.data.mongodb.core.mapping.Document
 
 @Document
-@CompoundIndex(name = "cmp-idx-by_id", def = "{'summoners.summoner.user.id': 1, 'summoners.id': 1, 'createdDate': -1}", unique = true)
+@CompoundIndex(name = "cmp-idx-by_id", def = "{'summoners.summoner.userId': 1, 'summoners.id': 1, 'createdDate': -1}", unique = true)
 @CompoundIndex(name = "cmp-idx-by_data", def = "{'createdDate': -1}", unique = true)
 class Statistics(
     @Id var id: ObjectId? = null,

--- a/common/src/main/kotlin/dev/yangsijun/gol/common/entity/summoner/Summoner.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/entity/summoner/Summoner.kt
@@ -10,7 +10,7 @@ import org.springframework.data.mongodb.core.mapping.Document
 @Document
 class Summoner(
     @Id var id: ObjectId? = null,
-    @DBRef(lazy = false) val user: User,
+    val userId: ObjectId,
     val summonerId: String,
     val accountId: String,
     val puuid: String,


### PR DESCRIPTION
DBRef를 사용해 User를 참조하고 있었는데, 이러면 Index 값으로 User의 ID를 사용할 수 없었다.
그래서 User 대신 User의 ID만 저장하도록 변경하였다.

+) User의 ID로 조회를 자주 하기 때문에 인덱스 값으로 무조건 사용해야 하는 상황이였음

다른 방법도 고려하긴 했는데, 가장 무난해서 선택함
다른 방법
1. DBRef + Manual Reference
2. User 비정규화해서 저장 