### PR TITLE
Summoner 비정규화 데이터인 SummonerField 추가 및 적용

### DIFF
--- a/batch/src/main/kotlin/dev/yangsijun/gol/batch/job/recordMatch/config/RecordMatchJobConfig.kt
+++ b/batch/src/main/kotlin/dev/yangsijun/gol/batch/job/recordMatch/config/RecordMatchJobConfig.kt
@@ -204,6 +204,7 @@ class RecordMatchJobConfig(
                     log.warn("Saved Match!! MatchId : {}",item)
                     return null
                 }
+                // value가 map이 아니면 내부 데이터를 찾을 수가 없음 -> 형변환해서 받기
                 val rs: Map<String, Map<Any, Any>> =
                     riotMatchByMatchIdApi.execute(item, 500) as Map<String, Map<Any, Any>>
                 val gamePlayersPuuid: List<String> = rs.get("metadata")?.get("participants") as List<String>

--- a/common/src/main/kotlin/dev/yangsijun/gol/common/entity/league/League.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/entity/league/League.kt
@@ -6,6 +6,7 @@ import dev.yangsijun.gol.common.common.enums.game.GameRankType
 import dev.yangsijun.gol.common.common.enums.game.TierType
 import dev.yangsijun.gol.common.common.util.GolObjectUtils
 import dev.yangsijun.gol.common.entity.summoner.Summoner
+import dev.yangsijun.gol.common.entity.summoner.SummonerField
 import org.bson.types.ObjectId
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.CompoundIndex
@@ -16,7 +17,7 @@ import org.springframework.data.mongodb.core.mapping.Document
 
 class League(
     @Id var id: ObjectId? = null,
-    val summoner: Summoner,
+    val summoner: SummonerField,
     val leagueId: String,
     val rankedType: RankedType,
     val tierType: TierType,

--- a/common/src/main/kotlin/dev/yangsijun/gol/common/entity/match/Match.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/entity/match/Match.kt
@@ -3,6 +3,7 @@ package dev.yangsijun.gol.common.entity.match
 
 import dev.yangsijun.gol.common.common.util.GolObjectUtils
 import dev.yangsijun.gol.common.entity.summoner.Summoner
+import dev.yangsijun.gol.common.entity.summoner.SummonerField
 import org.bson.types.ObjectId
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.CompoundIndex
@@ -15,7 +16,7 @@ import org.springframework.data.mongodb.core.mapping.Document
 class Match(
     @Id var id: ObjectId? = null,
     val data: Map<String, Any>,
-    val summoners: List<Summoner>
+    val summoners: List<SummonerField>
 ) {
     override fun toString() = GolObjectUtils.reflectionToString(this)
 }

--- a/common/src/main/kotlin/dev/yangsijun/gol/common/entity/ranking/Ranking.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/entity/ranking/Ranking.kt
@@ -4,6 +4,7 @@ package dev.yangsijun.gol.common.entity.ranking
 import dev.yangsijun.gol.common.common.enums.RankingType
 import dev.yangsijun.gol.common.common.util.GolObjectUtils
 import dev.yangsijun.gol.common.entity.summoner.Summoner
+import dev.yangsijun.gol.common.entity.summoner.SummonerField
 import org.bson.types.ObjectId
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.CompoundIndex
@@ -18,7 +19,7 @@ class Ranking(
     val place: Int, // n 순위
     val value: String, // 점수
     val additional: Map<String, Any> = emptyMap(), // 아무거나 더 필요한 자료
-    val summoner: Summoner
+    val summoner: SummonerField
 ) {
     override fun toString() = GolObjectUtils.reflectionToString(this)
 }

--- a/common/src/main/kotlin/dev/yangsijun/gol/common/entity/summoner/SummonerField.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/entity/summoner/SummonerField.kt
@@ -1,0 +1,29 @@
+package dev.yangsijun.gol.common.entity.summoner
+
+
+import dev.yangsijun.gol.common.common.util.GolObjectUtils
+import dev.yangsijun.gol.common.entity.user.User
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.DBRef
+import org.springframework.data.mongodb.core.mapping.Document
+import org.springframework.data.mongodb.core.mapping.DocumentReference
+import org.springframework.data.mongodb.core.mapping.Field
+
+/*
+ * 비정규화된 Summoner를 저장하는 경우 엔티티 대신 해당 객체를 사용한다.
+ *
+*/
+class SummonerField(
+    var id: ObjectId? = null,
+    val user: User,
+    val summonerId: String,
+    val accountId: String,
+    val puuid: String,
+    val name: String,
+    val profileIconId: Int,
+    val revisionDate: Long,
+    val summonerLevel: Long
+) {
+    override fun toString() = GolObjectUtils.reflectionToString(this)
+}

--- a/common/src/main/kotlin/dev/yangsijun/gol/common/entity/summoner/SummonerField.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/entity/summoner/SummonerField.kt
@@ -26,4 +26,19 @@ class SummonerField(
     val summonerLevel: Long
 ) {
     override fun toString() = GolObjectUtils.reflectionToString(this)
+    companion object {
+        fun from(summoner: Summoner) : SummonerField {
+            return SummonerField(
+                id = summoner.id,
+                user = summoner.user,
+                summonerId = summoner.summonerId,
+                accountId = summoner.accountId,
+                puuid = summoner.puuid,
+                name = summoner.name,
+                profileIconId = summoner.profileIconId,
+                revisionDate = summoner.revisionDate,
+                summonerLevel = summoner.summonerLevel
+            )
+        }
+    }
 }

--- a/common/src/main/kotlin/dev/yangsijun/gol/common/riot/mapper/ApiToLeagueMapper.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/riot/mapper/ApiToLeagueMapper.kt
@@ -5,6 +5,7 @@ import dev.yangsijun.gol.common.common.enums.game.RankedType
 import dev.yangsijun.gol.common.common.enums.game.TierType
 import dev.yangsijun.gol.common.entity.league.League
 import dev.yangsijun.gol.common.entity.summoner.Summoner
+import dev.yangsijun.gol.common.entity.summoner.SummonerField
 import dev.yangsijun.gol.common.riot.dto.LeagueApiResponse
 import org.bson.types.ObjectId
 
@@ -15,7 +16,7 @@ class ApiToLeagueMapper {
         fun responseToLeague(id: ObjectId?, response: LeagueApiResponse, summoner: Summoner): League {
             return League(
                 id = id,
-                summoner = summoner,
+                summoner = SummonerField.from(summoner),
                 leagueId = response.leagueId,
                 rankedType = RankedType.valueOf(response.queueType),
                 tierType = TierType.valueOf(response.tier),

--- a/common/src/main/kotlin/dev/yangsijun/gol/common/riot/mapper/ApiToMatchMapper.kt
+++ b/common/src/main/kotlin/dev/yangsijun/gol/common/riot/mapper/ApiToMatchMapper.kt
@@ -2,13 +2,14 @@ package dev.yangsijun.gol.common.riot.mapper
 
 import dev.yangsijun.gol.common.entity.match.Match
 import dev.yangsijun.gol.common.entity.summoner.Summoner
+import dev.yangsijun.gol.common.entity.summoner.SummonerField
 import org.bson.types.ObjectId
 
 class ApiToMatchMapper {
 
     companion object {
         fun responseToMatch(id: ObjectId?, response: Map<String, Any>, summoners: List<Summoner>): Match {
-            return Match(id, response, summoners)
+            return Match(id, response, summoners.map { summoner -> SummonerField.from(summoner) }.toList())
         }
     }
 }


### PR DESCRIPTION
Match나 League에는 해당 데이터가 저장되던 시점의 Summoner, User 정보를 저장하고 있어야 한다. 
하지만 기존의 `Summoner` 엔티티를 필드로 가지게 되면 User의 정보를 비정규화 하여 저장할 수 없다.
그래서 비정규화하여 Summoner를 저장하는 경우, User와 Summoner를 모두 비정규화하여 저장하는 SummonerField를 사용하도록 변경하였다.